### PR TITLE
Initialise query to prevent NullPointerException

### DIFF
--- a/src/main/java/com/github/Doomsdayrs/Jikan4java/core/search/Search.java
+++ b/src/main/java/com/github/Doomsdayrs/Jikan4java/core/search/Search.java
@@ -44,7 +44,7 @@ public class Search<T> extends Retriever {
     protected final Types type;
     protected T t;
     protected Class aClass;
-    protected String query = null;
+    protected String query = "";
     private int limit = 0;
 
     /**


### PR DESCRIPTION
Instead of setting query to null, set it to an empty string. Otherwise your 'query.replaceAll(" ", "%20")' call in createURL() will result in a NullPointerException, when the user hasn't set a query (cause they aren't looking for a specific title). You could also just add a check if query is null, but that's more code than my solution 😛